### PR TITLE
Add RustRover project directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ ferlium_history.txt
 /playground/dist/
 /site/
 /docs/book/en/book
+/.idea


### PR DESCRIPTION
JetBrains IDEs use `.idea` as project directory.