### PR TITLE
Record parameter passing requirement information in functions

### DIFF
--- a/doc/hir-ownership.md
+++ b/doc/hir-ownership.md
@@ -134,7 +134,11 @@ Dictionary elaboration resolves these unknowns using the final type:
 
 The interpreter and SSA lowering must consume this call-site metadata.
 They must not recompute source-level argument passing from the final function type.
-The physical direct-vs-indirect ABI decision remains a backend concern, as described in `doc/abi.md`.
+
+## High-level passing convention requirements vs. physical ABI
+
+The high-level passing convention requirement is available on call arguments and on the `ScriptFunction`'s `parameter_passing` field. Native (a.k.a. physical) calling conventions are obliged to pass arguments marked as `MutableRef`/`SharedRef`
+by pointer, but even `Value(TrivialCopy(layout))` may need to get passed indirectly as specified by `doc/abi.md`. E.g. `float64`, a `Value(TrivialCopy(layout))` type, is passed by reference on `wasm32` but by value on `wasm64`.
 
 # Function Values
 

--- a/src/hir/function.rs
+++ b/src/hir/function.rs
@@ -482,6 +482,10 @@ pub struct ScriptFunction {
     /// This includes closure-environment slots prepended when calling a function value, but not
     /// dictionary/evidence parameters, which are passed separately through the extra-parameter frame.
     pub runtime_arg_count: usize,
+    /// High-level argument passing requirements for each visible parameter, in declaration order.
+    ///
+    /// Length equals the number of visible parameters.
+    pub parameter_passing: Vec<ResolvedArgPassing>,
     // pub monomorphised: HashMap<Vec<Type>, hir::Node>,
 }
 

--- a/src/module/function.rs
+++ b/src/module/function.rs
@@ -564,6 +564,20 @@ impl PendingModuleFunction {
             &mut self.locals,
             ctx,
         )?;
+        // Classify the visible parameters (the leading locals) into their high-level passing requirements while
+        // the trait solver is available, so SSA lowering can read it back from the function body.
+        let arg_count = self.definition.arg_names.len();
+        let param_passing = (0..arg_count)
+            .map(|i| {
+                let arg_ty = self.definition.ty_scheme.ty.args[i];
+                let span = self.locals[i].name.1;
+                ctx.trait_solver
+                    .resolved_arg_passing_for_no_temp_arg(&mut self.code.arena, &arg_ty, span)
+                    .unwrap()
+                    .into_elaborated()
+            })
+            .collect::<Vec<_>>();
+
         if self.definition.returns_place() {
             if self.code.arena[root].ty != Type::never() {
                 return Err(internal_compilation_error!(Unsupported {
@@ -599,6 +613,7 @@ impl PendingModuleFunction {
             b(ScriptFunction::new(
                 elaborated.root,
                 self.code.runtime_arg_count,
+                param_passing,
             )),
             self.spans,
             locals,

--- a/src/types/trait_solver.rs
+++ b/src/types/trait_solver.rs
@@ -646,7 +646,7 @@ impl<'a> TraitSolver<'a> {
         Ok(ResolvedValueLayout { size, align })
     }
 
-    fn resolved_arg_passing_for_no_temp_arg(
+    pub(crate) fn resolved_arg_passing_for_no_temp_arg(
         &mut self,
         arena: &mut NodeArena,
         arg: &FnArgType,

--- a/tests/language/value.rs
+++ b/tests/language/value.rs
@@ -21,6 +21,7 @@ use ferlium::{
         id::Id,
     },
 };
+use ustr::ustr;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
@@ -1301,4 +1302,99 @@ fn value_impl_for_foreign_named_adt_is_rejected() {
         CompilationErrorImpl::TraitImplOrphanRuleViolation { .. } => {}
         other => panic!("expected TraitImplOrphanRuleViolation, got {other:?}"),
     }
+}
+
+// Testing resolved parameter passing for script functions, as described in `doc/hir-ownership.md`
+// ("Call Argument Passing").
+
+/// Compile `src` and return the resolved parameter passing of the script function `fn_name`.
+fn parameter_passing_for_fn(
+    session: &mut TestSession,
+    src: &str,
+    fn_name: &str,
+) -> Vec<ResolvedArgPassing> {
+    session
+        .compile_and_get_module(src)
+        .get_function(ustr(fn_name))
+        .expect("function should be defined")
+        .code
+        .as_script()
+        .expect("function should be a script function")
+        .parameter_passing
+        .clone()
+}
+
+fn trivial_copy_int() -> ResolvedArgPassing {
+    ResolvedArgPassing::Value(ResolvedValueArgPassing::TrivialCopy(int_value_layout()))
+}
+
+fn shared_ref() -> ResolvedArgPassing {
+    ResolvedArgPassing::Value(ResolvedValueArgPassing::SharedRef {
+        temp_cleanup: SharedRefTempCleanup::None,
+    })
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn concrete_trivial_copy_parameter_resolves_to_trivial_copy() {
+    let mut session = TestSession::new();
+    let passing =
+        parameter_passing_for_fn(&mut session, "fn id(value: int) -> int { value }", "id");
+    assert_eq!(passing, [trivial_copy_int()]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn non_trivial_copy_value_parameter_resolves_to_shared_ref() {
+    let mut session = TestSession::new();
+    let passing = parameter_passing_for_fn(
+        &mut session,
+        "fn identity(value: string) -> string { value }",
+        "identity",
+    );
+    assert_eq!(passing, [shared_ref()]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn mutable_parameter_resolves_to_mutable_ref() {
+    let mut session = TestSession::new();
+    let passing = parameter_passing_for_fn(
+        &mut session,
+        "fn store(slot: &mut int) { slot = 1; }",
+        "store",
+    );
+    assert_eq!(passing, [ResolvedArgPassing::MutableRef]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn generic_value_parameter_resolves_to_shared_ref() {
+    // A generic parameter is not treated as `TrivialCopy` even under a `Value` constraint.
+    let mut session = TestSession::new();
+    let passing = parameter_passing_for_fn(
+        &mut session,
+        "fn identity<T>(value: T) -> T where T: Value { value }",
+        "identity",
+    );
+    assert_eq!(passing, [shared_ref()]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn multiple_parameters_preserve_declaration_order() {
+    let mut session = TestSession::new();
+    let passing = parameter_passing_for_fn(
+        &mut session,
+        "fn mix(a: int, b: string, c: &mut int) -> int { c = a; a }",
+        "mix",
+    );
+    assert_eq!(
+        passing,
+        [
+            trivial_copy_int(),
+            shared_ref(),
+            ResolvedArgPassing::MutableRef
+        ]
+    );
 }


### PR DESCRIPTION
To resolve #148, I was thinking of 3 approaches:
- record passing convention requirement in function type (seemed impossible, types were immutable by the point we had the resolved passing convention info)
- add an optional field to local variables that represent parameters (looked a bit hacky)
- record convention requirements in ScriptFunction, in an additional vector with length equal the number of user-defined parameters

In this PR, I implemented the last approach, and checked in my other branch that the information can be wired through SSA lowering.
Let me know if you have any feedback, I'm happy to make adjustments if the way I exposed this data is not the most appropriate. Thank you!