### PR TITLE
Materialize a directly-matched temporary match scrutinee as an owned value

### DIFF
--- a/src/hir/match.rs
+++ b/src/hir/match.rs
@@ -21,6 +21,7 @@ use crate::{
     types::r#type::TypeKind,
 };
 use itertools::{Itertools, multiunzip};
+use ustr::ustr;
 
 use crate::{
     ast::{Pattern, PatternKind, PatternType},
@@ -636,17 +637,32 @@ impl TypeInference {
                 let default_id = alternatives.pop().unwrap().1;
                 (alternatives, default_id, effects)
             };
-            let case_ret_ty = if Self::case_arms_all_never(env, &alternatives, default_id) {
-                Type::never()
-            } else {
-                return_ty
-            };
-            let node = K::Case(b(hir::Case {
-                value: condition_node_id,
-                alternatives,
-                default: default_id,
-            }));
-            (node, case_ret_ty, MutType::constant(), effects)
+
+            // Materialize the scrutinee if needed.
+            let (kind, case_ty, case_effects) = self.consume_value_by_shared_ref(
+                env,
+                condition_node_id,
+                condition_ty,
+                match_span,
+                ustr("$match_scrutinee"),
+                move |_this, env, scrutinee| {
+                    let case_ret_ty = if Self::case_arms_all_never(env, &alternatives, default_id) {
+                        Type::never()
+                    } else {
+                        return_ty
+                    };
+                    (
+                        K::Case(b(hir::Case {
+                            value: scrutinee,
+                            alternatives,
+                            default: default_id,
+                        })),
+                        case_ret_ty,
+                        effects,
+                    )
+                },
+            );
+            (kind, case_ty, MutType::constant(), case_effects)
         })
     }
 

--- a/src/types/type_inference/expr.rs
+++ b/src/types/type_inference/expr.rs
@@ -3442,6 +3442,33 @@ impl TypeInference {
         self.block_or_cleanup_scope(prefix, drops)
     }
 
+    /// Builds a consumer that reads `value` by shared reference. A non-place `value` needing a
+    /// semantic drop is first bound to an owned `name` temporary dropped after the consumer (so it
+    /// acquires a `Value` obligation, like a shared-ref call argument); a place or trivially-copyable
+    /// `value` is consumed in place. `build_consumer` receives the node to consume — `value` or the
+    /// `LoadLocal` of its temporary — and returns its `(kind, type, effects)`.
+    pub(crate) fn consume_value_by_shared_ref(
+        &mut self,
+        env: &mut TypingEnv,
+        value: NodeId,
+        ty: Type,
+        span: Location,
+        name: Ustr,
+        build_consumer: impl FnOnce(&mut Self, &mut TypingEnv, NodeId) -> (NodeKind, Type, EffType),
+    ) -> (NodeKind, Type, EffType) {
+        if node_is_place_reference(env.ir_arena, value)
+            || !self.node_value_needs_semantic_drop(env, value, ty, span)
+        {
+            return build_consumer(self, env, value);
+        }
+        let temp_start = env.cur_locals.len();
+        let (store, load) = self.store_owned_temp(env, value, ty, span, name);
+        let (kind, consumer_ty, consumer_effects) = build_consumer(self, env, load);
+        let consumer = hir::Node::new(kind, consumer_ty, consumer_effects.clone(), span);
+        let block = self.wrap_call_with_temp_drops(env, temp_start, vec![store], consumer);
+        (block, consumer_ty, consumer_effects)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn wrap_owned_value_with_temp_drops(
         &mut self,

--- a/tests/language/annotations.rs
+++ b/tests/language/annotations.rs
@@ -581,3 +581,31 @@ fn array_index_ide_annotations_do_not_expose_generated_place_call() {
         "array index annotations should not expose generated addressor-place call details, got:\n{annotated}"
     );
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn match_on_temporary_scrutinee_acquires_value_obligation() {
+    // A non-place temporary scrutinee (here the call result `f(x)`) is materialized into an owned,
+    // dropped local, so its type acquires a `Value` obligation.
+    let src = "fn ho(f, x) { match f(x) { 0 => 1, _ => 2 } }";
+    let mut compiler = compile_source(src);
+    let annotations = annotation_hints(&mut compiler);
+    assert!(
+        annotations.contains("Value"),
+        "expected the matched temporary's type to acquire a `Value` obligation, got: {annotations}"
+    );
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn match_on_place_scrutinee_adds_no_value_obligation() {
+    // Dual of the test above: a place scrutinee (the parameter `x`) already owns its storage, is
+    // matched in place, and must NOT acquire a spurious `Value` obligation.
+    let src = "fn g(x) { match x { 0 => 1, _ => 2 } }";
+    let mut compiler = compile_source(src);
+    let annotations = annotation_hints(&mut compiler);
+    assert!(
+        !annotations.contains("Value"),
+        "a place scrutinee must not acquire a `Value` obligation, got: {annotations}"
+    );
+}

--- a/tests/language/complex.rs
+++ b/tests/language/complex.rs
@@ -104,6 +104,22 @@ fn exprs_in_match() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn match_on_temporary_scrutinee() {
+    // The scrutinee is a non-place temporary (a call result), materialized into an owned, dropped
+    // local before matching; it must still match correctly against an arm and the default.
+    let mut session = TestSession::new();
+    assert_val_eq!(
+        session.run("fn ho(f, x) { match f(x) { 1 => 10, _ => 20 } } ho(|z| z, 1)"),
+        int(10)
+    );
+    assert_val_eq!(
+        session.run("fn ho(f, x) { match f(x) { 1 => 10, _ => 20 } } ho(|z| z, 5)"),
+        int(20)
+    );
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn record_wildcards_in_match() {
     let mut session = TestSession::new();
     assert_val_eq!(


### PR DESCRIPTION
A `match` whose scrutinee is a temporary was not materialized in the HIR level, so when the value was a generic type, the value missed its `Value` dictionary extra parameter, which would be needed for dynamic stack allocation of the temporary and for dropping it after use. The goal of this PR is to make the `match` scrutinee behave similarly as a function argument's lowering that is used immutably.