### PR TITLE
Remove unneeded dictionary forwarded to `array_index` in derived deserialization

### DIFF
--- a/src/std/serde.rs
+++ b/src/std/serde.rs
@@ -430,9 +430,6 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
             let data_value_ty = data_value_type();
             let array_ty = array_type(data_value_ty);
             let value_trait_id = solver.std_trait_id(VALUE_TRAIT_NAME);
-            let data_value_dictionary_ty = solver
-                .trait_def(value_trait_id)
-                .get_dictionary_type_for_tys(&[data_value_ty], &[], &[]);
             let data_value_clone =
                 PendingLocalClone::Resolved(ResolvedLocalClone::Static(solver.solve_impl_method(
                     value_trait_id,
@@ -441,8 +438,6 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
                     span,
                     arena,
                 )?));
-            let data_value_dictionary =
-                solver.solve_impl(value_trait_id, &[data_value_ty], span, arena)?;
             // store it at 1
             let (store_array, l_array_id) = store_new_local(
                 get_array,
@@ -465,11 +460,6 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
                         arena,
                         immediate(LiteralValue::new_native(i as isize)),
                         int_type(),
-                    );
-                    let dictionary_node = n(
-                        arena,
-                        get_dictionary(data_value_dictionary),
-                        data_value_dictionary_ty,
                     );
                     let array_index = solver.get_subscript_member(
                         span,
@@ -505,7 +495,7 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
                             function: array_index,
                             function_path: None,
                             function_span: span,
-                            extra_arguments: vec![dictionary_node],
+                            extra_arguments: vec![],
                             arguments,
                             argument_names: vec![ustr("array"), ustr("index")],
                             ty,


### PR DESCRIPTION
## Problem

The compiler-synthesized `Deserialize` impls for tuples, records, and arrays
(`AlgebraicType*Deserialize` in `src/std/serde.rs`) decode each sub-value by
indexing the decoded sequence with the std subscript `array_index`. The
synthesized call forwarded a `Value<DataValue>` dictionary to `array_index` as
extra evidence:

```rust
extra_arguments: vec![dictionary_node],
```

But `array_index<A>(array: [A], index: int) -> A` strides a buffer of **uniform
`Value` slots**, so it needs no `Value<A>` element-layout dictionary and
declares **no** extra (dictionary) parameter. The normal `a[i]` lowering
forwards none either, so this synthesized call was the only place passing one.

The result is a call whose evidence list disagrees with the callee's signature:
it passes one dictionary into a function that declares zero extra parameters.

### Why it didn't surface

The HIR interpreter is lenient about evidence: it pushes all `extra_arguments`
onto an evidence stack and the callee reads only the parameters it references,
so a surplus dictionary is pushed-and-never-read and the mismatch is invisible
at runtime today.

It is a genuine IR defect, though: a strict, layout-explicit backend that binds
call operands positionally to typed parameter slots (e.g. an SSA/codegen
backend under development) cannot accept a dictionary operand in a non-dictionary
parameter slot, and rejects the call.

## Fix

Forward exactly the evidence `array_index` declares — none — and drop the now
unused `Value<DataValue>` dictionary computation:

```rust
extra_arguments: vec![],
```

This makes the synthesized call consistent with the callee's signature and with
the normal `a[i]` lowering. No behavior change on the HIR interpreter.

## Tests

No new test: the existing `serde` round-trip suite already deserializes tuples,
records, and arrays — exactly the composite kinds whose generated `Deserialize`
impls call `array_index` — so it already exercises this path (9/9 pass). The
mismatch is silently tolerated by the current HIR interpreter and only becomes a
hard error on a strict positional-evidence backend.