### PR TITLE
Fix match scrutinee not being dropped

### DIFF
--- a/src/hir/match.rs
+++ b/src/hir/match.rs
@@ -590,7 +590,9 @@ impl TypeInference {
             let effects = self.make_dependent_effect([store_eff, case_node_eff]);
             let node = K::Block(b(hir::Block {
                 body: b(SVec2::from_vec(vec![store_variant_node_id, case_node_id])),
-                cleanup: Vec::new(),
+                // The materialized scrutinee is an owned local; drop it when the block exits or a
+                // resource-owning scrutinee leaks (a `Skip`-drop one resolves to no drop).
+                cleanup: vec![l_match_condition],
             }));
             (node, case_ret_ty, MutType::constant(), effects)
         } else {

--- a/tests/language/value.rs
+++ b/tests/language/value.rs
@@ -227,8 +227,7 @@ fn call_argument_temp_is_dropped_when_later_argument_breaks() {
 }
 
 // A `match` materializes its scrutinee into an owned local; when an arm binds the payload by
-// reference (so the scrutinee stays live), that local must be dropped on block exit. Regression for
-// the scrutinee being omitted from the block's cleanup.
+// reference (so the scrutinee stays live), that local must be dropped on block exit.
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn match_scrutinee_temporary_is_dropped() {

--- a/tests/language/value.rs
+++ b/tests/language/value.rs
@@ -226,6 +226,28 @@ fn call_argument_temp_is_dropped_when_later_argument_breaks() {
     assert_val_eq!(session.run(&source), int(86));
 }
 
+// A `match` materializes its scrutinee into an owned local; when an arm binds the payload by
+// reference (so the scrutinee stays live), that local must be dropped on block exit. Regression for
+// the scrutinee being omitted from the block's cleanup.
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn match_scrutinee_temporary_is_dropped() {
+    let mut session = TestSession::new();
+    let source = format!(
+        r#"
+        {}
+        testing::reset_tracked_drops();
+        match Some(Probe(7)) {{
+            Some(p) => p.0,
+            None => 0,
+        }};
+        testing::tracked_drop_log()
+        "#,
+        tracked_probe_value_impl()
+    );
+    assert_val_eq!(session.run(&source), int(7));
+}
+
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn lexical_drop_runs_on_loop_continue() {


### PR DESCRIPTION
A `match` materializes its scrutinee into an owned local, but the block wrapping it is built with an empty cleanup list, so the local is never dropped.

When an arm binds the payload by reference the scrutinee stays live, so a resource-owning scrutinee leaks. The clearest case is a `for`-loop, which lowers to `match next(it) { Some(x) => …, None => break }` — the `Option` the iterator yields each iteration is never dropped.

The fix just adds the scrutinee local to the block's cleanup. The added test fails without it: the scrutinee's `Probe` drop never runs, so the recorded drop log is empty instead of `7`.
