### PR TITLE
Fix serde deserialize locals not being dropped

### DIFF
--- a/src/hir/hir_syn.rs
+++ b/src/hir/hir_syn.rs
@@ -218,3 +218,17 @@ pub fn block<P: HirPhase>(statements: impl IntoSVec2<NodeId<P>>) -> NodeKind<P> 
         cleanup: Vec::new(),
     }))
 }
+
+/// Like [`block`], but the listed owned locals are dropped when the block exits.
+///
+/// Generated HIR that leaves an owned local live at the tail must list it here, or it leaks:
+/// synthesized blocks don't get the type-checker's automatic per-scope cleanup.
+pub fn block_with_cleanup<P: HirPhase>(
+    statements: impl IntoSVec2<NodeId<P>>,
+    cleanup: Vec<LocalDeclId>,
+) -> NodeKind<P> {
+    K::Block(b(hir::Block {
+        body: b(statements.into_svec2()),
+        cleanup,
+    }))
+}

--- a/src/std/serde.rs
+++ b/src/std/serde.rs
@@ -520,8 +520,12 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
                 .collect::<Result<SVec2<_>, _>>()?;
             // build the tuple node
             let build_tuple = n(arena, tuple(build_elements), ty);
-            // assemble the final node
-            Some(n(arena, block([store_array, build_tuple]), ty))
+            // `array` is read, not consumed, so it is still live here and must be dropped.
+            Some(n(
+                arena,
+                block_with_cleanup([store_array, build_tuple], vec![l_array_id]),
+                ty,
+            ))
         } else if let TypeKind::Record(fields) = ty_data {
             /*
             Example source code for deserialization of a record:
@@ -584,8 +588,12 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
                 .collect::<Result<SVec2<_>, _>>()?;
             // build the record node
             let build_record = n(arena, record(build_elements), ty);
-            // assemble the final node
-            Some(n(arena, block([store_record, build_record]), ty))
+            // `record` is read, not consumed, so it is still live here and must be dropped.
+            Some(n(
+                arena,
+                block_with_cleanup([store_record, build_record], vec![l_record_id]),
+                ty,
+            ))
         } else if let TypeKind::Variant(variants) = ty_data {
             // Deserialize explicit enum variant data, while the helper also accepts the
             // adjacent-tagged record shape produced by the JSON codec.
@@ -654,8 +662,12 @@ impl Deriver for AlgebraicTypeDeserializeDeriver {
             // build the match node
             let panic_node = build_panic(arena, &mut locals, solver, "Unknown enum variant tag")?;
             let match_type = n(arena, case(get_name, variant_cases, panic_node), ty);
-            // assemble the final node
-            Some(n(arena, block([store_variant, match_type]), ty))
+            // `variant` is read, not consumed (the match borrows `variant.name`), so it must be dropped.
+            Some(n(
+                arena,
+                block_with_cleanup([store_variant, match_type], vec![l_variant_id]),
+                ty,
+            ))
         } else {
             None // deserialization of rest not yet supported
         };

--- a/tests/language/serde.rs
+++ b/tests/language/serde.rs
@@ -246,6 +246,24 @@ fn serialize_with_type_ascription() {
     );
 }
 
+// Exercises the three `deserialize` shapes (variant, record, array) that materialize an owned
+// `DataValue` local. Round-trips string content through each.
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn json_roundtrip_variant_record_array_with_strings() {
+    let mut session = TestSession::new();
+    assert_val_eq!(
+        session.run(r#"(json_decode(json_encode(Some("hi"))): None | Some(string))"#),
+        some(string("hi"))
+    );
+    assert_val_eq!(
+        session.run(
+            r#"(json_decode(json_encode({ tag: "x", items: ["a", "b"] })): { items: [string], tag: string }).tag"#
+        ),
+        string("x")
+    );
+}
+
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn json_serialization_roundtrip() {


### PR DESCRIPTION
serde's `deserialize` materializes the parsed `DataValue` into an owned local for variants, records, and arrays. The block wrapping each is built with an empty cleanup list, so the local is never dropped — it's read (not moved out), stays live, and leaks its owned strings.

The fix adds those locals to their block's cleanup, via a small `block_with_cleanup` helper.

The leak isn't observable on the tree-walking interpreter (the host reclaims the storage anyway), so there's no direct regression test for it here — it's caught by the SSA backend's discard invariant, which is where this fix was verified (a JSON round-trip of records/variants carrying strings no longer trips it). The added test round-trips all three shapes for correctness.
