### PR TITLE
Resolve mutable bindings' scope-exit drop from their type

### DIFF
--- a/src/types/type_inference/expr.rs
+++ b/src/types/type_inference/expr.rs
@@ -1028,9 +1028,13 @@ impl TypeInference {
                     expr_span,
                 );
                 if owns_storage {
-                    local.set_owned_storage(
-                        self.unresolved_or_skipped_drop_for_value(env, node_id, node_ty, expr_span),
-                    );
+                    local.set_owned_storage(self.unresolved_or_skipped_drop_for_value(
+                        env,
+                        node_id,
+                        node_ty,
+                        mut_val.is_mutable(),
+                        expr_span,
+                    ));
                 }
                 if defer_storage {
                     local.set_deferred_storage(DeferredLocalStorage {
@@ -4122,7 +4126,9 @@ impl TypeInference {
             None,
             span,
         );
-        local.set_owned_storage(self.unresolved_or_skipped_drop_for_value(env, value, ty, span));
+        local.set_owned_storage(
+            self.unresolved_or_skipped_drop_for_value(env, value, ty, false, span),
+        );
         let id = env.push_local(local);
 
         let value_effects = env.ir_arena[value].effects.clone();
@@ -4807,14 +4813,26 @@ impl TypeInference {
         !self.type_has_concrete_trivial_copy_impl(env, ty, span)
     }
 
+    /// Resolves the scope-exit drop of an owned binding initialized with `value`.
+    ///
+    /// An immutable binding holds its initializer for its whole lifetime, so drop necessity is
+    /// decided from the initializer value (e.g. a literal needs no drop even when its type is not
+    /// trivially copyable). A mutable binding can be reassigned an owned value, so its drop is
+    /// resolved from its type alone.
     fn unresolved_or_skipped_drop_for_value(
         &mut self,
         env: &mut TypingEnv,
         value: NodeId,
         ty: Type,
+        binding_mutable: bool,
         span: Location,
     ) -> PendingLocalDrop {
-        if self.node_value_needs_semantic_drop(env, value, ty, span) {
+        let needs_drop = if binding_mutable {
+            self.type_needs_semantic_drop(env, ty, span)
+        } else {
+            self.node_value_needs_semantic_drop(env, value, ty, span)
+        };
+        if needs_drop {
             self.add_value_constraint_for_unknown_drop(value_trait_id(env), ty, span);
             PendingLocalDrop::Unknown
         } else {
@@ -4831,8 +4849,10 @@ impl TypeInference {
         span: Location,
     ) {
         let owns_storage = !node_is_place_reference(env.ir_arena, value);
-        let drop =
-            owns_storage.then(|| self.unresolved_or_skipped_drop_for_value(env, value, ty, span));
+        let binding_mutable = env.all_locals[local_id.as_index()].mut_ty.is_mutable();
+        let drop = owns_storage.then(|| {
+            self.unresolved_or_skipped_drop_for_value(env, value, ty, binding_mutable, span)
+        });
 
         let local = &mut env.all_locals[local_id.as_index()];
         if let Some(drop) = drop {

--- a/tests/language/value.rs
+++ b/tests/language/value.rs
@@ -1714,3 +1714,58 @@ fn discarded_bool_struct_temporary_runs_semantic_drop() {
     "#;
     assert_val_eq!(session.run(source), int(1));
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn mutable_literal_initialized_local_drop_is_resolved_from_its_type() {
+    // A mutable binding can be reassigned an owned value, so its scope-exit drop must be
+    // resolved from its type; only an immutable binding may skip the drop based on its
+    // literal initializer.
+    let mut session = TestSession::new();
+    let module = session.compile_and_get_module(
+        r#"
+        fn go() -> string {
+            let ok = "a";
+            let mut s = "b";
+            s = string_concat(s, ok);
+            s
+        }
+        "#,
+    );
+    let go = module
+        .get_function_by_id(module.get_local_function_id(ustr("go")).unwrap())
+        .unwrap();
+    let drop_of = |name: &str| {
+        go.locals
+            .iter()
+            .find(|local| local.name.0 == ustr(name))
+            .unwrap_or_else(|| panic!("no local `{name}`"))
+            .local_drop()
+            .copied()
+    };
+    assert_eq!(drop_of("ok"), Some(ResolvedLocalDrop::Skip));
+    assert!(matches!(drop_of("s"), Some(ResolvedLocalDrop::Static(_))));
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn reassigned_mutable_literal_initialized_local_is_dropped_at_scope_exit() {
+    // The end-to-end scenario behind the resolution rule above: after reassignment `s` owns
+    // the `string_concat` result, which must be dropped each iteration before the loop reuses
+    // the local's storage. An ownership-explicit backend (e.g. the SSA lowering) leaks the
+    // string on every iteration without that drop.
+    let mut session = TestSession::new();
+    let source = r#"
+        fn go() -> int {
+            let mut i = 0;
+            loop {
+                let mut s = "a";
+                s = string_concat(s, "b");
+                i = i + 1;
+                if i > 2 { break i }
+            }
+        }
+        go()
+    "#;
+    assert_val_eq!(session.run(source), int(3));
+}

--- a/tests/language/value.rs
+++ b/tests/language/value.rs
@@ -1756,7 +1756,7 @@ fn reassigned_mutable_literal_initialized_local_is_dropped_at_scope_exit() {
     // string on every iteration without that drop.
     let mut session = TestSession::new();
     let source = r#"
-        fn go() -> int {
+        fn f() -> int {
             let mut i = 0;
             loop {
                 let mut s = "a";
@@ -1765,7 +1765,7 @@ fn reassigned_mutable_literal_initialized_local_is_dropped_at_scope_exit() {
                 if i > 2 { break i }
             }
         }
-        go()
+        f()
     "#;
     assert_val_eq!(session.run(source), int(3));
 }


### PR DESCRIPTION
## Problem

A mutable binding's scope-exit drop is resolved from its *initializer value*: `let mut s = "a"` gets `ResolvedLocalDrop::Skip` because a string literal alone needs no semantic drop. But a later assignment can make the binding own heap storage (e.g. `s = string_concat(s, "b")`), which then never receives its scope-exit drop.

The Rc-backed HIR interpreter reclaims the memory regardless, which is why this was never observable. Any ownership-explicit consumer of the elaborated HIR leaks the binding's final value — the in-progress SSA backend (#ssa-emitter branch) hits it directly: its debug interpreter panics with `SSA leak: store overwrites a live resource-owning value` when a loop reuses such a local's storage.

## Fix

`unresolved_or_skipped_drop_for_value` now takes the binding's mutability: a mutable binding resolves its drop from its **type**, while immutable bindings (whose content cannot change) keep the initializer-value shortcut.

This only *adds* drop obligations, and only for mutable bindings of non-named types (strings, literal aggregates). User `Value::drop` impls attach to named types, which already resolved by type — so no user-observable drop behavior changes. The full language test suite passes unchanged.

## Tests

- `mutable_literal_initialized_local_drop_is_resolved_from_its_type` — asserts the elaborated drop resolution directly (fails without the fix).
- `reassigned_mutable_literal_initialized_local_is_dropped_at_scope_exit` — the end-to-end loop scenario; behaviorally vacuous on the HIR interpreter but becomes a true leak regression test for ownership-explicit backends (the SSA branch's dual-run harness catches it).